### PR TITLE
chore(): Swagger config

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 spring.application.name=price-service
+
+# Swagger UI path
+springdoc.api-docs.path=/v3/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html


### PR DESCRIPTION
This pull request introduces a small but important change to the `application.properties` file by adding configuration properties for Swagger UI. These settings enable API documentation and provide a path for accessing the Swagger UI.

* [`src/main/resources/application.properties`](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136R2-R5): Added `springdoc.api-docs.path` and `springdoc.swagger-ui.path` properties to configure the Swagger UI and API documentation paths.