### PR TITLE
chore(): Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Step 1: Build the application
+FROM maven:3.9.6-eclipse-temurin-21 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+# Step 2: Create the runtime image
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
This pull request introduces a new `Dockerfile` to containerize the application. The file includes a multi-stage build process to optimize the image size and ensure a clean runtime environment.

Containerization:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R13): Added a multi-stage build process. The first stage uses the `maven:3.9.6-eclipse-temurin-21` image to build the application with Maven, skipping tests. The second stage creates a lightweight runtime image using `eclipse-temurin:21-jre`, copies the built JAR file, exposes port 8080, and sets the entry point to run the application.